### PR TITLE
Setup basic CI workflow in Sempahore CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,19 @@
+version: v1.0
+name: Elixir
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+  - name: mix test
+    task:
+      jobs:
+        - name: mix deps.get
+          commands:
+            - sem-version elixir 1.9
+            - checkout
+            - mix deps.get
+            - mix test
+      env_vars:
+        - name: MIX_ENV
+          value: test

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -10,7 +10,7 @@ blocks:
       jobs:
         - name: mix deps.get
           commands:
-            - sem-version elixir 1.9
+            - sem-version elixir 1.10
             - checkout
             - mix deps.get
             - mix test

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -5,15 +5,14 @@ agent:
     type: e1-standard-2
     os_image: ubuntu1804
 blocks:
-  - name: mix test
+  - name: build
     task:
       jobs:
-        - name: mix deps.get
+        - name: build
           commands:
             - sem-version elixir 1.10
             - checkout
-            - mix deps.get
-            - mix test
+            - make
       env_vars:
         - name: MIX_ENV
           value: test

--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,4 @@ deps:
 	mix deps.compile
 
 compile:
-	mix compile
+	mix compile --warnings-as-errors

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all deps compile test
+.PHONY: all deps compile test clean
 
 all: deps compile
 
@@ -11,3 +11,8 @@ compile:
 
 test:
 	mix test
+
+clean:
+	mix clean --all
+	mix deps.clean --all
+	rm -rf _build

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all deps compile
+.PHONY: all deps compile test
 
 all: deps compile
 
@@ -8,3 +8,6 @@ deps:
 
 compile:
 	mix compile --warnings-as-errors
+
+test:
+	mix test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Flix
 
+[![Build Status](https://efcasado.semaphoreci.com/badges/flix/branches/master.svg?style=shields)]
+
 An Elixir client for the [Flic](https://flic.io/) button.
 
 ### What's in the name?

--- a/lib/flix/protocol/commands.ex
+++ b/lib/flix/protocol/commands.ex
@@ -17,59 +17,59 @@ defmodule Flix.Protocol.Commands do
   }
 
   def decode(<<0::8-little, payload::binary>>) do
-    Flix.Protocol.Commands.GetInfo.decode(payload)
+    GetInfo.decode(payload)
   end
 
   def decode(<<1::8-little, payload::binary>>) do
-    Flix.Protocol.Commands.CreateScanner.decode(payload)
+    CreateScanner.decode(payload)
   end
 
   def decode(<<2::8-little, payload::binary>>) do
-    Flix.Protocol.Commands.RemoveScanner.decode(payload)
+    RemoveScanner.decode(payload)
   end
 
   def decode(<<3::8-little, payload::binary>>) do
-    Flix.Protocol.Commands.CreateConnectionChannel.decode(payload)
+    CreateConnectionChannel.decode(payload)
   end
 
   def decode(<<4::8-little, payload::binary>>) do
-    Flix.Protocol.Commands.RemoveConnectionChannel.decode(payload)
+    RemoveConnectionChannel.decode(payload)
   end
 
   def decode(<<5::8-little, payload::binary>>) do
-    Flix.Protocol.Commands.ForceDisconnect.decode(payload)
+    ForceDisconnect.decode(payload)
   end
 
   def decode(<<6::8-little, payload::binary>>) do
-    Flix.Protocol.Commands.ChangeModeParameters.decode(payload)
+    ChangeModeParameters.decode(payload)
   end
 
   def decode(<<7::8-little, payload::binary>>) do
-    Flix.Protocol.Commands.Ping.decode(payload)
+    Ping.decode(payload)
   end
 
   def decode(<<8::8-little, payload::binary>>) do
-    Flix.Protocol.Commands.GetButtonInfo.decode(payload)
+    GetButtonInfo.decode(payload)
   end
 
   def decode(<<9::8-little, payload::binary>>) do
-    Flix.Protocol.Commands.CreateScanWizard.decode(payload)
+    CreateScanWizard.decode(payload)
   end
 
   def decode(<<10::8-little, payload::binary>>) do
-    Flix.Protocol.Commands.CancelScanWizard.decode(payload)
+    CancelScanWizard.decode(payload)
   end
 
   def decode(<<11::8-little, payload::binary>>) do
-    Flix.Protocol.Commands.DeleteButton.decode(payload)
+    DeleteButton.decode(payload)
   end
 
   def decode(<<12::8-little, payload::binary>>) do
-    Flix.Protocol.Commands.CreateBatteryStatusListener.decode(payload)
+    CreateBatteryStatusListener.decode(payload)
   end
 
   def decode(<<13::8-little, payload::binary>>) do
-    Flix.Protocol.Commands.RemoveBatteryStatusListener.decode(payload)
+    RemoveBatteryStatusListener.decode(payload)
   end
 
   # def encode(command) do

--- a/lib/flix/protocol/commands/create_battery_status_listener.ex
+++ b/lib/flix/protocol/commands/create_battery_status_listener.ex
@@ -11,7 +11,7 @@ defmodule Flix.Protocol.Commands.CreateBatteryStatusListener do
     }
   end
 
-  def encode(%__MODULE__{listener_id: listener_id, bt_addr: bt_addr} = data) do
+  def encode(%__MODULE__{listener_id: listener_id, bt_addr: bt_addr} = _data) do
     bt_addr = Flix.Utils.bluetooth_address_to_binary(bt_addr)
 
     <<12::8-little, listener_id::32-little, bt_addr::little-bytes-6>>

--- a/lib/flix/protocol/commands/ping.ex
+++ b/lib/flix/protocol/commands/ping.ex
@@ -9,7 +9,7 @@ defmodule Flix.Protocol.Commands.Ping do
     }
   end
 
-  def encode(%__MODULE__{ping_id: ping_id} = data) do
+  def encode(%__MODULE__{ping_id: ping_id} = _data) do
     <<7::8-little, ping_id::32-little>>
   end
 end

--- a/lib/flix/protocol/events/scan_wizard_found_public_button.ex
+++ b/lib/flix/protocol/events/scan_wizard_found_public_button.ex
@@ -23,6 +23,7 @@ defmodule Flix.Protocol.Events.ScanWizardFoundPublicButton do
     nl2 = name_length * 8
 
     %__MODULE__{
+      scan_wizard_id: scan_wizard_id,
       bt_addr: bt_addr,
       name_length: name_length,
       name: <<name::size(nl2)>> |> String.reverse()


### PR DESCRIPTION
- [x] Set up Semaphore CI
- [x] Add Semaphore CI badge to README.md
- [x] Enable `--warnings-as-errors` flag

Also, this `PR` [fixes a bug](https://github.com/efcasado/flix/pull/3/files#diff-a63961d0dc9aa0e126e0d043a70d70cc8858154cd7c917f73bafeef78c1080efR26) where the `scan_wizard_id` field was not being properly set in the `ScanWizardFoundPublicButton` event.